### PR TITLE
Enclose object keys in string if it contains numbers

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,9 +21,10 @@ export const stringify = (obj: any, space = '  ', keepString = false) => {
         : str
     }
     if (node instanceof Array) return `[\n${node.map(x => indent + deep(x, depth)).join(',\n')}\n${padEnd}]`
+    const getValidObjectKey = (key: string) => /\d/.test(key) ? `'${key}'` : key
     return `{\n${
       Object.entries(node).map(([key, value]) =>
-          typeof value === 'function' ? deep(value, depth) : `${key}: ${deep(value, depth)}`,
+          typeof value === 'function' ? deep(value, depth) : `${getValidObjectKey(key)}: ${deep(value, depth)}`,
       ).map(x => indent + x).join(',\n')
     }\n${padEnd}}`
   }


### PR DESCRIPTION
Fixes a bug where it generates invalid object syntax if your swagger spec contains a path with a number. For example "/auth/2fa" would generate an object  { auth: { 2fa: {...} } }
This adds a check that wraps the key in single-quotes if the key contains a number, resulting in correct syntax, for example:
{ auth: { '2fa': {...} } }